### PR TITLE
Add Next.js starter with API stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.env

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "zazzytrade",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "next": "^14.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/pages/api/meta.js
+++ b/pages/api/meta.js
@@ -1,0 +1,20 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const response = await fetch('https://graph.facebook.com/v18.0/me/messages', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.META_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(req.body),
+    });
+    const data = await response.json();
+    return res.status(response.ok ? 200 : 500).json(data);
+  } catch (err) {
+    return res.status(500).json({ error: 'Failed to reach Meta API' });
+  }
+}

--- a/pages/api/openai.js
+++ b/pages/api/openai.js
@@ -1,0 +1,23 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: req.body.messages || [],
+      }),
+    });
+    const data = await response.json();
+    return res.status(response.ok ? 200 : 500).json(data);
+  } catch (err) {
+    return res.status(500).json({ error: 'Failed to reach OpenAI API' });
+  }
+}

--- a/pages/api/whatsapp.js
+++ b/pages/api/whatsapp.js
@@ -1,0 +1,23 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const response = await fetch(
+      `https://graph.facebook.com/v18.0/${process.env.WHATSAPP_PHONE_ID}/messages`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${process.env.WHATSAPP_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(req.body),
+      }
+    );
+    const data = await response.json();
+    return res.status(response.ok ? 200 : 500).json(data);
+  } catch (err) {
+    return res.status(500).json({ error: 'Failed to reach WhatsApp API' });
+  }
+}

--- a/pages/api/youtube.js
+++ b/pages/api/youtube.js
@@ -1,0 +1,15 @@
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const response = await fetch(
+      `https://www.googleapis.com/youtube/v3/search?part=snippet&q=${encodeURIComponent(req.query.q || '')}&key=${process.env.YOUTUBE_API_KEY}`
+    );
+    const data = await response.json();
+    return res.status(response.ok ? 200 : 500).json(data);
+  } catch (err) {
+    return res.status(500).json({ error: 'Failed to reach YouTube API' });
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Home() {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold">Inbox Dashboard Starter</h1>
+      <p className="mt-2">Replace this content with the provided HTML UI.</p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js project with placeholder inbox dashboard page
- add API route stubs for Meta, YouTube, WhatsApp, and OpenAI

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd440e2f448333bb4c538e0081cd21