### PR TITLE
Add mobile-first ChatGPT web UI example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Rename this file to .env and replace with your OpenAI API key
+OPENAI_API_KEY=your-openai-api-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # zazzytrade
+
 zazzytrade-project
+
+## ChatGPT API Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Copy `.env.example` to `.env` and replace the placeholder with your OpenAI API key:
+   ```bash
+   cp .env.example .env
+   # edit .env and set OPENAI_API_KEY
+   ```
+3. Run the example script to verify your key:
+   ```bash
+   python chatgpt_example.py
+   ```
+   If the key is missing, the script will prompt you to add it.
+
+## Web UI
+
+1. Start the Flask app:
+   ```bash
+   python app.py
+   ```
+2. Open `http://localhost:5000` in a browser to use the mobile‑friendly chat interface.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,28 @@
+import os
+from flask import Flask, render_template, request, jsonify
+
+try:
+    from openai import OpenAI
+except ImportError:
+    raise SystemExit("The 'openai' package is required. Install it with 'pip install openai'.")
+
+app = Flask(__name__)
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+@app.route("/chat", methods=["POST"])
+def chat():
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return jsonify({"error": "OPENAI_API_KEY is not set"}), 500
+    data = request.get_json() or {}
+    user_message = data.get("message", "")
+    client = OpenAI(api_key=api_key)
+    response = client.responses.create(model="gpt-4o-mini", input=user_message)
+    reply = response.output[0].content[0].text
+    return jsonify({"reply": reply})
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/chatgpt_example.py
+++ b/chatgpt_example.py
@@ -1,0 +1,25 @@
+import os
+
+try:
+    from openai import OpenAI
+except ImportError:
+    raise SystemExit("The 'openai' package is required. Install it with 'pip install openai'.")
+
+
+def main() -> None:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        print("OPENAI_API_KEY is not set. Copy .env.example to .env and add your key.")
+        return
+
+    client = OpenAI(api_key=api_key)
+    response = client.responses.create(
+        model="gpt-4o-mini",
+        input="Hello from ZazzyTrade!",
+    )
+    message = response.output[0].content[0].text
+    print(message)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+openai

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,42 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 1rem;
+  background: #f5f5f5;
+}
+main {
+  max-width: 600px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+#chat {
+  flex: 1;
+  overflow-y: auto;
+  background: #fff;
+  padding: 1rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+}
+form {
+  display: flex;
+}
+input {
+  flex: 1;
+  padding: 0.5rem;
+  font-size: 1rem;
+}
+button {
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+}
+.msg {
+  margin-bottom: 0.5rem;
+}
+@media (min-width: 600px) {
+  body {
+    padding: 2rem;
+  }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ZazzyTrade Chat</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <main>
+    <h1>ZazzyTrade Chat</h1>
+    <div id="chat"></div>
+    <form id="chat-form">
+      <input type="text" id="message" placeholder="Type your message" required />
+      <button type="submit">Send</button>
+    </form>
+  </main>
+  <script>
+    const form = document.getElementById('chat-form');
+    const chat = document.getElementById('chat');
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const input = document.getElementById('message');
+      const text = input.value.trim();
+      if (!text) return;
+      appendMessage('You', text);
+      input.value = '';
+      const res = await fetch('/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text })
+      });
+      if (res.ok) {
+        const data = await res.json();
+        appendMessage('Bot', data.reply);
+      } else {
+        appendMessage('Error', 'Request failed');
+      }
+    });
+
+    function appendMessage(sender, text) {
+      const div = document.createElement('div');
+      div.className = 'msg';
+      div.innerHTML = `<strong>${sender}:</strong> ${text}`;
+      chat.appendChild(div);
+      chat.scrollTop = chat.scrollHeight;
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask web app serving a mobile-first chat interface
- document setup steps and dependencies for web UI
- include requirements file for Flask and OpenAI

## Testing
- `pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement flask)
- `python chatgpt_example.py` (fails: The 'openai' package is required)
- `python app.py` (fails: No module named 'flask')

------
https://chatgpt.com/codex/tasks/task_e_68bcd7d7dd508333b0720ea19737656c